### PR TITLE
Allow a zero string '0' as translation value and prevent filtering. B…

### DIFF
--- a/src/Spryker/Zed/GlossaryStorage/Business/Writer/GlossaryTranslationStorageWriter.php
+++ b/src/Spryker/Zed/GlossaryStorage/Business/Writer/GlossaryTranslationStorageWriter.php
@@ -135,7 +135,7 @@ class GlossaryTranslationStorageWriter implements GlossaryTranslationStorageWrit
             $idGlossaryKey = $glossaryTranslationEntityTransfer->getFkGlossaryKey();
             $localeName = $glossaryTranslationEntityTransfer->getLocale()->getLocaleName();
 
-            if ((!$glossaryTranslationEntityTransfer->getIsActive() || !$glossaryTranslationEntityTransfer->getGlossaryKey()->getIsActive() || trim($glossaryTranslationEntityTransfer->getValue()) === "")) {
+            if (!$glossaryTranslationEntityTransfer->getIsActive() || !$glossaryTranslationEntityTransfer->getGlossaryKey()->getIsActive() || (string) $glossaryTranslationEntityTransfer->getValue() === "") {
                 unset($glossaryTranslationEntityTransfers[$id]);
 
                 if (isset($mappedGlossaryStorageEntityTransfers[$idGlossaryKey][$localeName])) {

--- a/src/Spryker/Zed/GlossaryStorage/Business/Writer/GlossaryTranslationStorageWriter.php
+++ b/src/Spryker/Zed/GlossaryStorage/Business/Writer/GlossaryTranslationStorageWriter.php
@@ -135,7 +135,7 @@ class GlossaryTranslationStorageWriter implements GlossaryTranslationStorageWrit
             $idGlossaryKey = $glossaryTranslationEntityTransfer->getFkGlossaryKey();
             $localeName = $glossaryTranslationEntityTransfer->getLocale()->getLocaleName();
 
-            if ((!$glossaryTranslationEntityTransfer->getIsActive() || !$glossaryTranslationEntityTransfer->getGlossaryKey()->getIsActive() || !$glossaryTranslationEntityTransfer->getValue())) {
+            if ((!$glossaryTranslationEntityTransfer->getIsActive() || !$glossaryTranslationEntityTransfer->getGlossaryKey()->getIsActive() || trim($glossaryTranslationEntityTransfer->getValue()) === "")) {
                 unset($glossaryTranslationEntityTransfers[$id]);
 
                 if (isset($mappedGlossaryStorageEntityTransfers[$idGlossaryKey][$localeName])) {


### PR DESCRIPTION
…ut keep filtering of NULL and all empty strings (even more than 1 whitespace)

## PR Description

In our project a valid translation string could be "0", "1" ,"2", ... in a context of product sizes.
But "0" will be treated as not set and filtered out before writing to storage table.

The change would allow "0" but not empty strings (NULL would be converted to empty string by trim()).

## Checklist
- [x ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
